### PR TITLE
'web-frame' module deprecated, switched to 'electron'.webFrame

### DIFF
--- a/lib/hidpi.coffee
+++ b/lib/hidpi.coffee
@@ -1,5 +1,5 @@
 {CompositeDisposable} = require 'atom'
-WebFrame = require 'web-frame'
+WebFrame = require('electron').webFrame
 class Hidpi
   subscriptions: null
   currentScaleFactor: 1.0


### PR DESCRIPTION
Fixes #14 and #16.
